### PR TITLE
build a multi platform docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: verify build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    name: verify goreleaser build (all platforms)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser build
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: v2
+          args: build --snapshot --clean
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries
+          path: dist/*/my-app*
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,21 @@ jobs:
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: ./linter-results.sarif
+          category: golangci-lint
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
+        with:
+          dockerfile: Dockerfile
+          format: sarif
+          output-file: hadolint-results.sarif
+          no-fail: true # findings are reported but never fail the build, see golangci-lint above
+
+      - name: Upload Hadolint SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: ./hadolint-results.sarif
+          category: hadolint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload_assets.yml
+++ b/.github/workflows/upload_assets.yml
@@ -4,9 +4,8 @@ on:
       - 'v*'
 
 env:
-    # name of the resulting binary and the docker-image. must match name
-    # in .goreleaser.yml
-    BINARY: my-app
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 name: Upload release assets after tagging
 jobs:
@@ -15,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,43 +26,10 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
-        with:
-          version: v2
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: binary
-          path: dist/go-ci-demo_linux_amd64_v1/${{ env.BINARY }}
-          retention-days: 1
-
-  docker-image:
-    needs: build
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-
-    name: create docker image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: image=moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 # buildx-stable-1
-          #buildkitd-flags: --debug
 
       - name: Log in to the Container registry
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
@@ -71,44 +38,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Download the binary artifact from the build job
-      - name: Download binary artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          name: binary
-          path: ./docker-build
-
-      - name: Prepare docker build
-        run: |
-          cp Dockerfile ./docker-build
-          chmod 755 ./docker-build/${{ env.BINARY }}
-
-      - name: Get tag info for image label
-        id: tag
-        run: |
-            TAG=$(git describe --tags)
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
-
-      - name: Compute image tags
-        id: image-tags
-        run: |
-          {
-            echo "tags<<EOF"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}"
-            if [ "${{ steps.tag.outputs.tag }}" != "v99.9.9" ]; then
-              echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./docker-build
-          build-args: |
-            binary=${{ env.BINARY }}
-          push: true
-          tags: ${{ steps.image-tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          version: v2
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,31 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
+dockers_v2:
+  - ids:
+      - go-ci-demo
+    dockerfile: Dockerfile
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    images:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}"
+    tags:
+      - "{{ .FullCommit }}"
+      - "{{ .Tag }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    labels:
+      org.opencontainers.image.source: "https://github.com/{{ .Env.IMAGE_NAME }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+    annotations:
+      org.opencontainers.image.source: "https://github.com/{{ .Env.IMAGE_NAME }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+
+release:
+  prerelease: auto
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/distroless/static-debian12
-ARG binary
+ARG TARGETPLATFORM
 LABEL maintainer="Jan Delgado <jdelgado@gmx.net>"
 
-COPY ./$binary /app
+COPY $TARGETPLATFORM/my-app /app
 ENTRYPOINT ["/app"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 - [Creating a release](#creating-a-release)
 - [Linting & Test](#linting--test)
   - [Linter](#linter)
+  - [Dockerfile linting](#dockerfile-linting)
   - [Test](#test)
+  - [Build verification](#build-verification)
 - [Testing the pipeline](#testing-the-pipeline)
 - [Author](#author)
 
@@ -36,7 +38,8 @@ final multi-plattform assets, which are automatically uploaded to the
 The [release-process](#creating-a-release) is triggered by pushing a git tag to
 the repository.
 
-Finally, a docker image is built, which gets published to
+Finally, a multi-platform (`linux/amd64` and `linux/arm64`) docker image is
+built, which gets published to
 [ghcr.io](https://github.com/jandelgado/golang-ci-template-github-actions/pkgs/container/golang-ci-template-github-actions).
 Run it with
 
@@ -107,11 +110,15 @@ The push of the new tag triggers the CI, which uses goreleaser with
 - create a new release
 - upload the artifacts, which are then available on the [releases page](/jandelgado/golang-ci-template-github-actions/releases).
 
-Finally, a docker image is built using the previously built artifacts. The image
-is published to
+Finally, goreleaser builds a single multi-platform (`linux/amd64` +
+`linux/arm64`) docker image directly, via [`dockers_v2`](.goreleaser.yml)
+(the successor to the now-deprecated `dockers`/`docker_manifests` config, see
+[goreleaser deprecations](https://goreleaser.com/deprecations/#dockers)),
+published to
 [ghcr.io](https://github.com/jandelgado/golang-ci-template-github-actions/pkgs/container/golang-ci-template-github-actions).
 
-To run goreleaser locally, start the tool with `goreleaser build --snapshot --clean`.
+To run goreleaser locally, start the tool with `goreleaser build --snapshot --clean`
+(see [Build verification](#build-verification) below for how this is also checked in CI).
 
 ## Linting & Test
 
@@ -137,6 +144,13 @@ $ go tool -modfile=tools/go.mod golangci-lint run
 See [Tool dependencies](#tool-dependencies) for why golangci-lint is pinned
 this way.
 
+### Dockerfile linting
+
+[hadolint](https://github.com/hadolint/hadolint), run via
+[hadolint-action](https://github.com/hadolint/hadolint-action), lints the
+[Dockerfile](Dockerfile). Like golangci-lint above, findings are uploaded as
+SARIF but `no-fail: true` keeps the build green regardless of findings.
+
 ### Test
 
 We use the
@@ -147,27 +161,46 @@ Don't forget to enable `Leave comments (x)` in coveralls, under
 `repo settings` > `pull request alerts`, so that the coveralls-action posts a comment
 with the test coverage to affected pull requests:
 
+### Build verification
+
+Since the actual multi-platform docker build (see [Creating a
+release](#creating-a-release)) can only run as part of a real
+`goreleaser release`, the [`build`](.github/workflows/build.yml) workflow
+instead runs `goreleaser build --snapshot --clean` on every push/PR as a fast,
+docker-free smoke check that the code still cross-compiles for all
+configured platforms, using the exact same build config as a real release.
+The resulting binaries are uploaded as a `binaries` workflow artifact so they
+can be downloaded and inspected without waiting for a release.
+
 ## Testing the pipeline
 
-To test the full release pipeline without affecting the `latest` docker tag,
-push a `v99.9.9` tag. The docker image job special-cases this version and skips
-updating `latest`.
+To test the full release pipeline, including the actual multi-arch docker
+build and push, push a pre-release tag, e.g. `v0.0.0-test`. Goreleaser
+recognizes the semver pre-release suffix (the part after the `-`) and
+- marks the created GitHub release as "pre-release" (`release.prerelease: auto`)
+- skips updating the `latest` docker tag (the `latest` entry in `dockers_v2[].tags`
+  is templated as `{{ if not .Prerelease }}latest{{ end }}`, so it renders empty
+  and is dropped for pre-release tags)
 
-To revert everything a `v99.9.9` test release created either click through the Github-UI
-or use these commands:
+both automatically, without needing any special-cased version number.
+
+To revert everything a `v0.0.0-test` test release created either click through
+the Github-UI or use these commands:
 
 ```console
 # delete the GitHub release (keep the tag for now)
-$ gh release delete v99.9.9 --yes
+$ gh release delete v0.0.0-test --yes
 
 # delete the git tag, locally and on the remote
-$ git tag -d v99.9.9 && git push origin :refs/tags/v99.9.9
+$ git tag -d v0.0.0-test && git push origin :refs/tags/v0.0.0-test
 
 # delete the matching docker image version from ghcr.io
-# (the gh CLI's default token lacks package scopes; request them once)
+# (dockers_v2 pushes a single multi-platform manifest per release, so there's
+# just one version to remove; the gh CLI's default token lacks package
+# scopes, so request them once)
 $ gh auth refresh -h github.com -s read:packages,delete:packages
 $ VERSION_ID=$(gh api /user/packages/container/golang-ci-template-github-actions/versions \
-    --jq '.[] | select(.metadata.container.tags[]? == "v99.9.9") | .id')
+    --jq '.[] | select(.metadata.container.tags[]? == "v0.0.0-test") | .id')
 $ gh api --method DELETE /user/packages/container/golang-ci-template-github-actions/versions/$VERSION_ID
 ```
 


### PR DESCRIPTION
- Use goreleaser to build a multi platform docker image for amd64 and arm64 platforms. 
- Add a build step to make sure everything can be build with goreleaser so the pipeline does not later fail when a git tag is pushed
- also lint the Dockerfile
